### PR TITLE
Discuss : using native libs AND keeping 3 mac/linux/win targets at the same time

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,20 +11,35 @@ dependencies {
 }
 
 kotlin {
-    macosX64("native-mac") {
+    val hostOs = System.getProperty("os.name")
+    val isMingwX64 = hostOs.startsWith("Windows")
+    val nativeTarget = when {
+        hostOs == "Mac OS X" -> macosX64("native")
+        hostOs == "Linux" -> linuxX64("native")
+        isMingwX64 -> mingwX64("native")
+        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+    }
+
+    nativeTarget.apply {
         binaries {
             executable()
         }
     }
-    linuxX64("native-linux") {
-        binaries {
-            executable()
-        }
-    }
-    mingwX64("native-win") {
-        binaries {
-            executable()
-        }
-    }
+
+//    macosX64("native-mac") {
+//        binaries {
+//            executable()
+//        }
+//    }
+//    linuxX64("native-linux") {
+//        binaries {
+//            executable()
+//        }
+//    }
+//    mingwX64("native-win") {
+//        binaries {
+//            executable()
+//        }
+//    }
 }
 

--- a/src/nativeMain/kotlin/hello.kt
+++ b/src/nativeMain/kotlin/hello.kt
@@ -1,5 +1,10 @@
+import utils.Files
+
 fun main() {
-    println("Salut, Frédéric. Fib(90) = ${fib(90)}")
+    println("Salut, Frédéric !. Fib(90) = ${fib(90)}")
+
+    val json = Files.readAllText("./hello.json")
+    println("""Read json : ${json}""")
 }
 
 fun fib(n: Long): Long = fib(n, mutableMapOf())

--- a/src/nativeMain/kotlin/utils/Files.kt
+++ b/src/nativeMain/kotlin/utils/Files.kt
@@ -1,0 +1,38 @@
+package utils
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import platform.posix.*
+
+// Kudos to https://www.nequalsonelifestyle.com/2020/11/16/kotlin-native-file-io/
+// and https://twitter.com/neqone/status/1363634263292338176
+class Files {
+    companion object {
+        private const val READ_MODE = "r"
+        private const val WRITE_MODE = "w"
+
+        fun readAllText(filePath: String): String {
+            val returnBuffer = StringBuilder()
+            val file = fopen(filePath, READ_MODE) ?:
+            throw IllegalArgumentException("Cannot open input file $filePath")
+
+            try {
+                memScoped {
+                    val readBufferLength = 64 * 1024
+                    val buffer = allocArray<ByteVar>(readBufferLength)
+                    var line = fgets(buffer, readBufferLength, file)?.toKString()
+                    while (line != null) {
+                        returnBuffer.append(line)
+                        line = fgets(buffer, readBufferLength, file)?.toKString()
+                    }
+                }
+            } finally {
+                fclose(file)
+            }
+
+            return returnBuffer.toString()
+        }
+    }
+}


### PR DESCRIPTION
Hi Cédric,

I stumbled upon a limitation in yesterday's skeleton : in my CLI, I needed to read some `File` and discovered that no `File` API was available in the MMP world (at least, no JDK-like one, because Kotlin native is not using the JDK)

I found this blog post : https://nequalsonelifestyle.com/2020/11/16/kotlin-native-file-io/ (with source code here : https://gitlab.com/HankG/codepad/-/tree/master/kotlin/native/samples/NativeAppFIleIO)
which helped me a lot to use POSIX api to read files (based on the plain old `C` API), and to be able to rely on this POSIX native lib, I had to extract the code outside the `commonMain` sourceset, which doesn't contain native lib in its classpath
![commonMain_classpath](https://user-images.githubusercontent.com/603815/108704348-2a9e3200-750c-11eb-8558-ad1307e0c9a2.png)

and move it to a manually-defined `nativeMain` sourceset aimed at containing my platform's (mac) posix stdlib in the classpath to be able to execute some POSIX functions :
![nativeMain_classpath](https://user-images.githubusercontent.com/603815/108704422-499cc400-750c-11eb-9f23-1c0d74490231.png)

My concern is : while doing this, I'm losing the "multi-target" which was allowing to cross generate my executable for linux/win/mac platforms.
![4i18n_–_Files_kt__hello_nativeMain_](https://user-images.githubusercontent.com/603815/108705403-90d78480-750d-11eb-9fdb-4fea5141203e.png)


Any idea from a Gradle expert to solve this, beautifully (I could create 3 sourcesets with the same source inside it, but hum, that's ugly :-) )
I mean ... having at the same time :
- Kind of a "commonNative" sourceset, allowing to share common (native) source code with `commonMain` implementations
- Thus allowing to still generate 3 executables for the mac/linux/win targets